### PR TITLE
[OLXIN-22653]: Refactor media loading to use Coroutines and version bump

### DIFF
--- a/mediapicker/build.gradle
+++ b/mediapicker/build.gradle
@@ -64,7 +64,7 @@ afterEvaluate {
 
                 groupId = 'com.github.IndiaOlx'
                 artifactId = 'media-picker-android'
-                version = '2.0.22'
+                version = '2.0.23'
 
                 pom {
                     name = 'Media Picker Android'

--- a/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/LoadPhotoViewModel.kt
+++ b/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/LoadPhotoViewModel.kt
@@ -14,6 +14,8 @@ import com.mediapicker.gallery.domain.entity.IGalleryItem
 import com.mediapicker.gallery.domain.entity.PhotoAlbum
 import com.mediapicker.gallery.domain.entity.PhotoFile
 import com.mediapicker.gallery.presentation.viewmodels.factory.BaseLoadMediaViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class LoadPhotoViewModel(private val application: Application) :
     BaseLoadMediaViewModel(application) {
@@ -47,23 +49,23 @@ class LoadPhotoViewModel(private val application: Application) :
 
     override fun getUniqueLoaderId() = 1
 
-    override fun prepareDataForAdapterAndPost(cursor: Cursor) {
-        val listOfGalleryItems: MutableList<IGalleryItem> = ArrayList()
-        if (cursor.moveToFirst()) {
-            val photos = ArrayList<IGalleryItem>()
-            do {
-                val photo = getPhoto(cursor)
-                photos.add(photo)
-            } while (cursor.moveToNext())
-            listOfGalleryItems.clear()
+    override suspend fun prepareDataForAdapterAndPost(cursor: Cursor) =
+        withContext(Dispatchers.IO) {
+            val listOfGalleryItems: MutableList<IGalleryItem> = ArrayList()
             if (needToAddCameraView())
                 listOfGalleryItems.add(CameraItem())
             if (needToAddFolderView())
                 listOfGalleryItems.add(PhotoAlbum.dummyInstance)
-            listOfGalleryItems.addAll(getFinalListOfGalleryItems(photos))
+            if (cursor.moveToFirst()) {
+                val photos = ArrayList<IGalleryItem>()
+                do {
+                    val photo = getPhoto(cursor)
+                    photos.add(photo)
+                } while (cursor.moveToNext())
+                listOfGalleryItems.addAll(getFinalListOfGalleryItems(photos))
+            }
+            galleryItemsLiveData.postValue(listOfGalleryItems)
         }
-        galleryItemsLiveData.postValue(listOfGalleryItems)
-    }
 
 //    private fun unregisterDataSetObserver() {
 //        if (lastLoadedCursor != null && isObserverRegistered) {

--- a/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/LoadVideoViewModel.kt
+++ b/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/LoadVideoViewModel.kt
@@ -12,6 +12,8 @@ import androidx.loader.content.CursorLoader
 import androidx.loader.content.Loader
 import com.mediapicker.gallery.GalleryConfig
 import com.mediapicker.gallery.presentation.viewmodels.factory.BaseLoadMediaViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.Serializable
 
 class LoadVideoViewModel(private val application: Application) :
@@ -55,35 +57,36 @@ class LoadVideoViewModel(private val application: Application) :
 
     override fun getUniqueLoaderId() = 2
 
-    override fun prepareDataForAdapterAndPost(cursor: Cursor) {
-        val videoList = mutableListOf<VideoItem>()
-        val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media._ID)
-        val nameColumn =
-            cursor.getColumnIndexOrThrow(MediaStore.Video.Media.DISPLAY_NAME)
-        val durationColumn =
-            cursor.getColumnIndexOrThrow(MediaStore.Video.Media.DURATION)
-        val sizeColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media.SIZE)
+    override suspend fun prepareDataForAdapterAndPost(cursor: Cursor) =
+        withContext(Dispatchers.IO) {
+            val videoList = mutableListOf<VideoItem>()
+            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media._ID)
+            val nameColumn =
+                cursor.getColumnIndexOrThrow(MediaStore.Video.Media.DISPLAY_NAME)
+            val durationColumn =
+                cursor.getColumnIndexOrThrow(MediaStore.Video.Media.DURATION)
+            val sizeColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media.SIZE)
 
-        videoList.add(RecordVideoItem())
-        if (cursor.moveToFirst()) {
-            do {
-                val id = cursor.getLong(idColumn)
-                val name = cursor.getString(nameColumn)
-                val duration = cursor.getInt(durationColumn)
-                val size = cursor.getInt(sizeColumn)
-                val contentUri: Uri =
-                    ContentUris.withAppendedId(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, id)
-                val thumbnail = MediaStore.Video.Thumbnails.getThumbnail(
-                    application.contentResolver,
-                    id, MediaStore.Video.Thumbnails.MICRO_KIND, null
-                )
-                if (!name.isNullOrBlank() && duration > 0)
-                    videoList += VideoFile(id, contentUri, name, duration, size, thumbnail)
-            } while (cursor.moveToNext())
+            videoList.add(RecordVideoItem())
+            if (cursor.moveToFirst()) {
+                do {
+                    val id = cursor.getLong(idColumn)
+                    val name = cursor.getString(nameColumn)
+                    val duration = cursor.getInt(durationColumn)
+                    val size = cursor.getInt(sizeColumn)
+                    val contentUri: Uri =
+                        ContentUris.withAppendedId(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, id)
+                    val thumbnail = MediaStore.Video.Thumbnails.getThumbnail(
+                        application.contentResolver,
+                        id, MediaStore.Video.Thumbnails.MICRO_KIND, null
+                    )
+                    if (!name.isNullOrBlank() && duration > 0)
+                        videoList += VideoFile(id, contentUri, name, duration, size, thumbnail)
+                } while (cursor.moveToNext())
+            }
+            loadingStateLiveData.postValue(StateData.SUCCESS)
+            videoItemLiveData.postValue(videoList)
         }
-        loadingStateLiveData.postValue(StateData.SUCCESS)
-        videoItemLiveData.postValue(videoList)
-    }
 }
 
 interface VideoItem

--- a/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/factory/BaseLoadMediaViewModel.kt
+++ b/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/factory/BaseLoadMediaViewModel.kt
@@ -5,10 +5,12 @@ import android.database.Cursor
 import android.os.Bundle
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import androidx.loader.app.LoaderManager
 import androidx.loader.content.Loader
 import com.mediapicker.gallery.presentation.viewmodels.StateData
-import java.util.concurrent.Executors
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 abstract class BaseLoadMediaViewModel(application: Application) : AndroidViewModel(application),
     LoaderManager.LoaderCallbacks<Cursor> {
@@ -26,7 +28,7 @@ abstract class BaseLoadMediaViewModel(application: Application) : AndroidViewMod
 
     abstract fun getUniqueLoaderId(): Int
 
-    abstract fun prepareDataForAdapterAndPost(cursor: Cursor)
+    abstract suspend fun prepareDataForAdapterAndPost(cursor: Cursor)
 
 
     override fun onCreateLoader(id: Int, args: Bundle?): Loader<Cursor> {
@@ -34,7 +36,7 @@ abstract class BaseLoadMediaViewModel(application: Application) : AndroidViewMod
     }
 
     override fun onLoadFinished(loader: Loader<Cursor>, data: Cursor?) {
-        Executors.newSingleThreadExecutor().submit {
+        viewModelScope.launch {
             data?.let {
                 prepareDataForAdapterAndPost(it)
                 loadingStateLiveData.postValue(StateData.SUCCESS)


### PR DESCRIPTION
* Migrated media loading logic from `Executors` to `viewModelScope` in `BaseLoadMediaViewModel`.
* Updated `prepareDataForAdapterAndPost` to a `suspend` function to support non-blocking data processing.
* Offloaded `Cursor` iteration and data mapping to `Dispatchers.IO` in `LoadVideoViewModel` and `LoadPhotoViewModel` to prevent UI thread blocking.
* Refactored `LoadPhotoViewModel` to improve the initialization of gallery items.
* Updated library version to `2.0.23` in `build.gradle`.