### PR TITLE
  Fix gallery StaleDataException and empty cursor loading state

### DIFF
--- a/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/LoadPhotoViewModel.kt
+++ b/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/LoadPhotoViewModel.kt
@@ -49,23 +49,22 @@ class LoadPhotoViewModel(private val application: Application) :
 
     override fun getUniqueLoaderId() = 1
 
-    override suspend fun prepareDataForAdapterAndPost(cursor: Cursor) =
-        withContext(Dispatchers.IO) {
-            val listOfGalleryItems: MutableList<IGalleryItem> = ArrayList()
-            if (needToAddCameraView())
-                listOfGalleryItems.add(CameraItem())
-            if (needToAddFolderView())
-                listOfGalleryItems.add(PhotoAlbum.dummyInstance)
-            if (cursor.moveToFirst()) {
-                val photos = ArrayList<IGalleryItem>()
-                do {
-                    val photo = getPhoto(cursor)
-                    photos.add(photo)
-                } while (cursor.moveToNext())
-                listOfGalleryItems.addAll(getFinalListOfGalleryItems(photos))
-            }
-            galleryItemsLiveData.postValue(listOfGalleryItems)
+    override fun prepareDataForAdapterAndPost(cursor: Cursor) {
+        val listOfGalleryItems: MutableList<IGalleryItem> = ArrayList()
+        if (needToAddCameraView())
+            listOfGalleryItems.add(CameraItem())
+        if (needToAddFolderView())
+            listOfGalleryItems.add(PhotoAlbum.dummyInstance)
+        if (cursor.moveToFirst()) {
+            val photos = ArrayList<IGalleryItem>()
+            do {
+                val photo = getPhoto(cursor)
+                photos.add(photo)
+            } while (cursor.moveToNext())
+            listOfGalleryItems.addAll(getFinalListOfGalleryItems(photos))
         }
+        galleryItemsLiveData.postValue(listOfGalleryItems)
+    }
 
 //    private fun unregisterDataSetObserver() {
 //        if (lastLoadedCursor != null && isObserverRegistered) {

--- a/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/LoadPhotoViewModel.kt
+++ b/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/LoadPhotoViewModel.kt
@@ -14,8 +14,6 @@ import com.mediapicker.gallery.domain.entity.IGalleryItem
 import com.mediapicker.gallery.domain.entity.PhotoAlbum
 import com.mediapicker.gallery.domain.entity.PhotoFile
 import com.mediapicker.gallery.presentation.viewmodels.factory.BaseLoadMediaViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 class LoadPhotoViewModel(private val application: Application) :
     BaseLoadMediaViewModel(application) {
@@ -50,20 +48,27 @@ class LoadPhotoViewModel(private val application: Application) :
     override fun getUniqueLoaderId() = 1
 
     override fun prepareDataForAdapterAndPost(cursor: Cursor) {
+        val photos = ArrayList<IGalleryItem>()
+        if (!cursor.isClosed && cursor.moveToFirst()) {
+            do {
+                photos.add(getPhoto(cursor))
+            } while (!cursor.isClosed && cursor.moveToNext())
+        }
+        galleryItemsLiveData.postValue(buildGalleryItemList(photos))
+    }
+
+    override fun prepareEmptyDataForAdapterAndPost() {
+        galleryItemsLiveData.postValue(buildGalleryItemList(emptyList()))
+    }
+
+    private fun buildGalleryItemList(photos: List<IGalleryItem>): List<IGalleryItem> {
         val listOfGalleryItems: MutableList<IGalleryItem> = ArrayList()
         if (needToAddCameraView())
             listOfGalleryItems.add(CameraItem())
         if (needToAddFolderView())
             listOfGalleryItems.add(PhotoAlbum.dummyInstance)
-        if (cursor.moveToFirst()) {
-            val photos = ArrayList<IGalleryItem>()
-            do {
-                val photo = getPhoto(cursor)
-                photos.add(photo)
-            } while (cursor.moveToNext())
-            listOfGalleryItems.addAll(getFinalListOfGalleryItems(photos))
-        }
-        galleryItemsLiveData.postValue(listOfGalleryItems)
+        listOfGalleryItems.addAll(getFinalListOfGalleryItems(photos))
+        return listOfGalleryItems
     }
 
 //    private fun unregisterDataSetObserver() {

--- a/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/LoadVideoViewModel.kt
+++ b/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/LoadVideoViewModel.kt
@@ -65,7 +65,7 @@ class LoadVideoViewModel(private val application: Application) :
         val sizeColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media.SIZE)
 
         videoList.add(RecordVideoItem())
-        if (cursor.moveToFirst()) {
+        if (!cursor.isClosed && cursor.moveToFirst()) {
             do {
                 val id = cursor.getLong(idColumn)
                 val name = cursor.getString(nameColumn)
@@ -79,8 +79,14 @@ class LoadVideoViewModel(private val application: Application) :
                 )
                 if (!name.isNullOrBlank() && duration > 0)
                     videoList += VideoFile(id, contentUri, name, duration, size, thumbnail)
-            } while (cursor.moveToNext())
+            } while (!cursor.isClosed && cursor.moveToNext())
         }
+        loadingStateLiveData.postValue(StateData.SUCCESS)
+        videoItemLiveData.postValue(videoList)
+    }
+
+    override fun prepareEmptyDataForAdapterAndPost() {
+        val videoList = listOf<VideoItem>(RecordVideoItem())
         loadingStateLiveData.postValue(StateData.SUCCESS)
         videoItemLiveData.postValue(videoList)
     }

--- a/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/LoadVideoViewModel.kt
+++ b/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/LoadVideoViewModel.kt
@@ -12,8 +12,6 @@ import androidx.loader.content.CursorLoader
 import androidx.loader.content.Loader
 import com.mediapicker.gallery.GalleryConfig
 import com.mediapicker.gallery.presentation.viewmodels.factory.BaseLoadMediaViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import java.io.Serializable
 
 class LoadVideoViewModel(private val application: Application) :
@@ -57,36 +55,35 @@ class LoadVideoViewModel(private val application: Application) :
 
     override fun getUniqueLoaderId() = 2
 
-    override suspend fun prepareDataForAdapterAndPost(cursor: Cursor) =
-        withContext(Dispatchers.IO) {
-            val videoList = mutableListOf<VideoItem>()
-            val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media._ID)
-            val nameColumn =
-                cursor.getColumnIndexOrThrow(MediaStore.Video.Media.DISPLAY_NAME)
-            val durationColumn =
-                cursor.getColumnIndexOrThrow(MediaStore.Video.Media.DURATION)
-            val sizeColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media.SIZE)
+    override fun prepareDataForAdapterAndPost(cursor: Cursor) {
+        val videoList = mutableListOf<VideoItem>()
+        val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media._ID)
+        val nameColumn =
+            cursor.getColumnIndexOrThrow(MediaStore.Video.Media.DISPLAY_NAME)
+        val durationColumn =
+            cursor.getColumnIndexOrThrow(MediaStore.Video.Media.DURATION)
+        val sizeColumn = cursor.getColumnIndexOrThrow(MediaStore.Video.Media.SIZE)
 
-            videoList.add(RecordVideoItem())
-            if (cursor.moveToFirst()) {
-                do {
-                    val id = cursor.getLong(idColumn)
-                    val name = cursor.getString(nameColumn)
-                    val duration = cursor.getInt(durationColumn)
-                    val size = cursor.getInt(sizeColumn)
-                    val contentUri: Uri =
-                        ContentUris.withAppendedId(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, id)
-                    val thumbnail = MediaStore.Video.Thumbnails.getThumbnail(
-                        application.contentResolver,
-                        id, MediaStore.Video.Thumbnails.MICRO_KIND, null
-                    )
-                    if (!name.isNullOrBlank() && duration > 0)
-                        videoList += VideoFile(id, contentUri, name, duration, size, thumbnail)
-                } while (cursor.moveToNext())
-            }
-            loadingStateLiveData.postValue(StateData.SUCCESS)
-            videoItemLiveData.postValue(videoList)
+        videoList.add(RecordVideoItem())
+        if (cursor.moveToFirst()) {
+            do {
+                val id = cursor.getLong(idColumn)
+                val name = cursor.getString(nameColumn)
+                val duration = cursor.getInt(durationColumn)
+                val size = cursor.getInt(sizeColumn)
+                val contentUri: Uri =
+                    ContentUris.withAppendedId(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, id)
+                val thumbnail = MediaStore.Video.Thumbnails.getThumbnail(
+                    application.contentResolver,
+                    id, MediaStore.Video.Thumbnails.MICRO_KIND, null
+                )
+                if (!name.isNullOrBlank() && duration > 0)
+                    videoList += VideoFile(id, contentUri, name, duration, size, thumbnail)
+            } while (cursor.moveToNext())
         }
+        loadingStateLiveData.postValue(StateData.SUCCESS)
+        videoItemLiveData.postValue(videoList)
+    }
 }
 
 interface VideoItem

--- a/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/factory/BaseLoadMediaViewModel.kt
+++ b/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/factory/BaseLoadMediaViewModel.kt
@@ -28,7 +28,7 @@ abstract class BaseLoadMediaViewModel(application: Application) : AndroidViewMod
 
     abstract fun getUniqueLoaderId(): Int
 
-    abstract suspend fun prepareDataForAdapterAndPost(cursor: Cursor)
+    abstract fun prepareDataForAdapterAndPost(cursor: Cursor)
 
 
     override fun onCreateLoader(id: Int, args: Bundle?): Loader<Cursor> {

--- a/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/factory/BaseLoadMediaViewModel.kt
+++ b/mediapicker/src/main/java/com/mediapicker/gallery/presentation/viewmodels/factory/BaseLoadMediaViewModel.kt
@@ -30,17 +30,20 @@ abstract class BaseLoadMediaViewModel(application: Application) : AndroidViewMod
 
     abstract fun prepareDataForAdapterAndPost(cursor: Cursor)
 
+    abstract fun prepareEmptyDataForAdapterAndPost()
 
     override fun onCreateLoader(id: Int, args: Bundle?): Loader<Cursor> {
         return getCursorLoader()
     }
 
     override fun onLoadFinished(loader: Loader<Cursor>, data: Cursor?) {
-        viewModelScope.launch {
-            data?.let {
-                prepareDataForAdapterAndPost(it)
-                loadingStateLiveData.postValue(StateData.SUCCESS)
+        viewModelScope.launch(Dispatchers.Main.immediate) {
+            if (data != null && !data.isClosed) {
+                prepareDataForAdapterAndPost(data)
+            } else {
+                prepareEmptyDataForAdapterAndPost()
             }
+            loadingStateLiveData.postValue(StateData.SUCCESS)
         }
     }
 


### PR DESCRIPTION
Summary

  CursorLoader can close its cursor after onLoadFinished returns. Reading it from a deferred coroutine caused StaleDataException when building the photo grid.

  Changes

  • BaseLoadMediaViewModel: Use Dispatchers.Main.immediate so cursor reads run before the loader can reset; if cursor is null/closed, call empty-data path; always post SUCCESS.
  • LoadPhotoViewModel: Guard cursor iteration with isClosed; shared buildGalleryItemList() for normal and empty loads (camera/folder tiles when configured).
  • LoadVideoViewModel: Same cursor guards; empty load posts RecordVideoItem only.

  Result

  • Avoids crash from stale cursor access.
  • Empty/null cursor → empty gallery UI, loader not stuck on LOADING.